### PR TITLE
The gist of going to XAML.Standard

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -8,21 +8,37 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
-	public abstract class BindableObject : INotifyPropertyChanged, IDynamicResourceHandler
+	[Obsolete("Use DependencyObject")]
+	public abstract class BindableObject : DependencyObject { }
+
+	public abstract class DependencyObject : INotifyPropertyChanged, IDynamicResourceHandler
 	{
+		[Obsolete("Use DataContextProperty")]
 		public static readonly BindableProperty BindingContextProperty =
 			BindableProperty.Create("BindingContext", typeof(object), typeof(BindableObject), default(object),
-									BindingMode.OneWay, null, BindingContextPropertyChanged, null, null, BindingContextPropertyBindingChanging);
+									BindingMode.OneWay, null, DataContextPropertyChanged, null, null, BindingContextPropertyBindingChanging);
+
+		public static readonly BindableProperty DataContextProperty =
+		BindableProperty.Create("DataContext", typeof(object), typeof(DependencyObject), default(object),
+								BindingMode.OneWay, null, DataContextPropertyChanged, null, null, DataContextPropertyBindingChanging);
+
 
 		readonly List<BindablePropertyContext> _properties = new List<BindablePropertyContext>(4);
 
 		bool _applying;
 		object _inheritedContext;
 
+		[Obsolete("Use DataContextProperty")]
 		public object BindingContext
 		{
 			get { return _inheritedContext ?? GetValue(BindingContextProperty); }
 			set { SetValue(BindingContextProperty, value); }
+		}
+
+		public object DataContext
+		{
+			get { return _inheritedContext ?? GetValue(DataContextProperty); }
+			set { SetValue(DataContextProperty, value); }
 		}
 
 		void IDynamicResourceHandler.SetDynamicResource(BindableProperty property, string key)
@@ -439,8 +455,13 @@ namespace Xamarin.Forms
 				binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged: fromBindingContextChanged);
 			}
 		}
-
 		static void BindingContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
+		{
+			object context = bindable._inheritedContext;
+			bindable.SetValue(DataContextProperty, newBindingBase);
+		}
+
+		static void DataContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
 		{
 			object context = bindable._inheritedContext;
 			var oldBinding = oldBindingBase as Binding;
@@ -452,10 +473,10 @@ namespace Xamarin.Forms
 				newBinding.Context = context;
 		}
 
-		static void BindingContextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+		static void DataContextPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
 		{
 			bindable._inheritedContext = null;
-			bindable.ApplyBindings(skipBindingContext: true, fromBindingContextChanged:true);
+			bindable.ApplyBindings(skipBindingContext: true, fromBindingContextChanged: true);
 			bindable.OnBindingContextChanged();
 		}
 

--- a/Xamarin.Forms.Core/Entry.cs
+++ b/Xamarin.Forms.Core/Entry.cs
@@ -5,20 +5,25 @@ using Xamarin.Forms.Platform;
 
 namespace Xamarin.Forms
 {
-	[RenderWith(typeof(_EntryRenderer))]
-	public class Entry : InputView, IFontElement, ITextElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
+	[Obsolete("Use TextBlock")]
+	public class Entry : TextBlock, IElementConfiguration<Entry>
 	{
-		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(Entry), default(string));
+	}
 
-		public static readonly BindableProperty IsPasswordProperty = BindableProperty.Create("IsPassword", typeof(bool), typeof(Entry), default(bool));
+	[RenderWith(typeof(_EntryRenderer))]
+	public class TextBlock : InputView, IFontElement, ITextElement, ITextAlignmentElement, IEntryController, IElementConfiguration<TextBlock>
+	{
+		public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create("Placeholder", typeof(string), typeof(TextBlock), default(string));
 
-		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(Entry), null, BindingMode.TwoWay, propertyChanged: OnTextChanged);
+		public static readonly BindableProperty IsPasswordProperty = BindableProperty.Create("IsPassword", typeof(bool), typeof(TextBlock), default(bool));
+
+		public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(string), typeof(TextBlock), null, BindingMode.TwoWay, propertyChanged: OnTextChanged);
 
 		public static readonly BindableProperty TextColorProperty = TextElement.TextColorProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
-		public static readonly BindableProperty PlaceholderColorProperty = BindableProperty.Create("PlaceholderColor", typeof(Color), typeof(Entry), Color.Default);
+		public static readonly BindableProperty PlaceholderColorProperty = BindableProperty.Create("PlaceholderColor", typeof(Color), typeof(TextBlock), Color.Default);
 
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
@@ -26,11 +31,11 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		readonly Lazy<PlatformConfigurationRegistry<Entry>> _platformConfigurationRegistry;
+		readonly Lazy<PlatformConfigurationRegistry<TextBlock>> _platformConfigurationRegistry;
 
-		public Entry()
+		public TextBlock()
 		{
-			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Entry>>(() => new PlatformConfigurationRegistry<Entry>(this));
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<TextBlock>>(() => new PlatformConfigurationRegistry<TextBlock>(this));
 		}
 
 		public TextAlignment HorizontalTextAlignment
@@ -89,7 +94,7 @@ namespace Xamarin.Forms
 		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
-			Device.GetNamedSize(NamedSize.Default, (Entry)this);
+			Device.GetNamedSize(NamedSize.Default, (TextBlock)this);
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
@@ -113,14 +118,14 @@ namespace Xamarin.Forms
 			Completed?.Invoke(this, EventArgs.Empty);
 		}
 
-		static void OnTextChanged(BindableObject bindable, object oldValue, object newValue)
+		static void OnTextChanged(DependencyObject bindable, object oldValue, object newValue)
 		{
-			var entry = (Entry)bindable;
+			var entry = (TextBlock)bindable;
 
 			entry.TextChanged?.Invoke(entry, new TextChangedEventArgs((string)oldValue, (string)newValue));
 		}
 
-		public IPlatformElementConfiguration<T, Entry> On<T>() where T : IConfigPlatform
+		public IPlatformElementConfiguration<T, TextBlock> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
 		}


### PR DESCRIPTION
No breaking changes.
`Entry` marked obsoleted, helping people to move toward TextBox (I realize that could be controversial so that's only a suggestion).
`BindingContext` is now just backed by `DataContext`, but works the same way.
`BindableObject` is now known as `DependencyObject`, but still exists and thus isn't breaking existing users.
